### PR TITLE
fix text decoration and links

### DIFF
--- a/index.html
+++ b/index.html
@@ -310,7 +310,14 @@
                           >
                             <div class="accordion-header js-accordion-header">
                               <div class="accordion_question-wrap">
-                                <span class="faq_question">Shapeshift</span>
+                                <span class="faq_question"
+                                  ><a
+                                    href="https://app.arbor.finance/offerings/399"
+                                    target="_blank"
+                                    class="text-[#75ed02]"
+                                    >Shapeshift</a
+                                  ></span
+                                >
                                 <p class="italic">&nbsp; | Current</p>
                               </div>
                             </div>
@@ -323,8 +330,9 @@
                                 </a>
                                 |
                                 <a
-                                  href="https://app.arbor.finance/bonds/0x2e2a42fbe7c7e2ffc031baf7442dbe1f8957770a"
+                                  href="https://app.arbor.finance/offerings/399"
                                   target="_blank"
+                                  class="text-[#75ed02]"
                                   >Bond Information</a
                                 >
                                 <p>


### PR DESCRIPTION
<img width="500" alt="image" src="https://user-images.githubusercontent.com/99197390/208148143-2b1c8811-07c9-40b3-9a33-ede19fc1afb4.png">


- [x] Fixed the text decoration to green so that the Shapeshift offering stands out
- [x] Changed Bond Information link to redirect to the auction page
- [x] Added link to the auction page from the Shapeshift title